### PR TITLE
bugfix panic: assignment to entry in nil map

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -48,6 +48,9 @@ func parse(insomnia Insomnia) map[string]map[string][]Resource {
 		}
 		if resource.Type == REQUEST {
 			fetchVariables(&resource)
+			if _, ok := entities[resource.ParentID]; !ok {
+				entities[resource.ParentID] = make(map[string][]Resource, 0)
+			}
 			entities[resource.ParentID][resource.URL] = append(entities[resource.ParentID][resource.URL], resource)
 		}
 	}


### PR DESCRIPTION
### Description
➜  Downloads ./swaggymnia generate -i Insomnia_2021-10-26.json -o json -c config.json
panic: assignment to entry in nil map

goroutine 1 [running]:
main.parse(0xc420016b10, 0x6, 0x4, 0xed9095a9c, 0x206cc800, 0x0, 0xc42000ad80, 0x1e, 0xc42017e000, 0xd7, ...)
	C:/Users/Mohamed/go/src/github.com/mlabouardy/swaggymnia/swagger.go:51 +0x32c
main.(*Swagger).Generate(0xc4201057d8, 0x7ffeefbff791, 0x18, 0x7ffeefbff7b5, 0xb, 0x7ffeefbff7ad, 0x4)
	C:/Users/Mohamed/go/src/github.com/mlabouardy/swaggymnia/swagger.go:83 +0x11f
main.main.func1(0xc42008c840, 0x10100, 0xc42008c840)
	C:/Users/Mohamed/go/src/github.com/mlabouardy/swaggymnia/app.go:57 +0x180
github.com/urfave/cli.HandleAction(0x11bd260, 0x12080d8, 0xc42008c840, 0xc420076300, 0x0)
	C:/Users/Mohamed/go/src/github.com/urfave/cli/app.go:502 +0xd4
github.com/urfave/cli.Command.Run(0x11fab4d, 0x8, 0x0, 0x0, 0xc4200168b0, 0x1, 0x1, 0x1202246, 0x1e, 0x0, ...)
	C:/Users/Mohamed/go/src/github.com/urfave/cli/command.go:210 +0xb87
github.com/urfave/cli.(*App).Run(0xc4200d01c0, 0xc42000e080, 0x8, 0x8, 0x0, 0x0)
	C:/Users/Mohamed/go/src/github.com/urfave/cli/app.go:259 +0x7b7
main.main()
	C:/Users/Mohamed/go/src/github.com/mlabouardy/swaggymnia/app.go:66 +0x515

### Related Issue
#16 #10 #8 #7 

### Changes proposed 
resource of type REQUEST mybe appear before it's parent  of REQUEST_GROUP 

### Screenshots
![image](https://user-images.githubusercontent.com/13761028/138801123-3dae89e6-831c-4e1d-8588-8fc33d47173f.png)
